### PR TITLE
cdコマンドの改善

### DIFF
--- a/src/builtin/builtin.c
+++ b/src/builtin/builtin.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin.c                                          :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rhonda <rhonda@student.42.fr>              +#+  +:+       +#+        */
+/*   By: msawada <msawada@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/14 09:21:21 by rhonda            #+#    #+#             */
-/*   Updated: 2025/03/21 21:39:45 by rhonda           ###   ########.fr       */
+/*   Updated: 2025/03/22 22:44:11 by msawada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,7 +65,5 @@ int	exec_builtin(t_command *current, t_shell *shell, t_command *node)
 		todo("exec_builtin");
 	free_argv(argv);
 	reset_redirect(current->command->redirects);
-	free_map(shell->envmap);
-	free_node(node);
 	return (status);
 }

--- a/src/builtin/builtin_pwd.c
+++ b/src/builtin/builtin_pwd.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_pwd.c                                      :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rhonda <rhonda@student.42.fr>              +#+  +:+       +#+        */
+/*   By: msawada <msawada@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/15 18:15:18 by rhonda            #+#    #+#             */
-/*   Updated: 2025/03/21 21:40:06 by rhonda           ###   ########.fr       */
+/*   Updated: 2025/03/22 22:41:00 by msawada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -19,12 +19,11 @@ bool	is_equal_inode(const char *path1, const char *path2)
 
 	ft_memset(&st1, 0, sizeof(st1));
 	ft_memset(&st2, 0, sizeof(st2));
-	if (stat(path1, &st1) < 0)
-		fatal_error("stat");
-	if (stat(path2, &st2) < 0)
-		fatal_error("stat");
+	if (stat(path1, &st1) < 0 || stat(path2, &st2) < 0)
+		return (false);
 	return (st1.st_ino == st2.st_ino);
 }
+
 
 int	builtin_pwd(char **argv, t_shell *shell)
 {

--- a/src/exec/exec.c
+++ b/src/exec/exec.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   exec.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: rhonda <rhonda@student.42.fr>              +#+  +:+       +#+        */
+/*   By: msawada <msawada@student.42.fr>            +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/12 06:55:46 by rhonda            #+#    #+#             */
-/*   Updated: 2025/03/21 21:36:18 by rhonda           ###   ########.fr       */
+/*   Updated: 2025/03/22 22:44:55 by msawada          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,6 +75,7 @@ int	exec_nonbuiltin(t_command *node, t_shell *shell)
 static pid_t	exec_pipeline(t_command *current, t_shell *shell, t_command *node)
 {
 	pid_t		pid;
+	int status;
 
 	if (!current)
 		return (-1);
@@ -89,7 +90,12 @@ static pid_t	exec_pipeline(t_command *current, t_shell *shell, t_command *node)
 			exit(EXIT_FAILURE);
 		prepare_pipe_child(current);
 		if (is_builtin(current))
-			exit(exec_builtin(current, shell, node));
+		{
+			status = exec_builtin(current, shell, node);
+			free_map(shell->envmap);
+			free_node(node);
+			exit(status);
+		}
 		else
 			exec_nonbuiltin(current, shell);
 	}
@@ -103,6 +109,8 @@ int	exec(t_command *node, t_shell *shell)
 {
 	pid_t	last_pid;
 
+	if (is_builtin(node) && node->next == NULL)
+		return (exec_builtin(node, shell, node));
 	last_pid = exec_pipeline(node, shell, node);
 	shell->last_status = wait_pipeline(last_pid);
 	return (shell->last_status);


### PR DESCRIPTION
cdコマンドの挙動を修正しました。

・パイプありの場合は実行できるけど、実際には移動しない。
・パイプありの場合は移動出来るようになっています。

is_equal_inode関数の影響で正常なコマンドでも
Fatal Error: statが出ていたので、そこも修正しました。


